### PR TITLE
Update all_features_version_10_no_visit_variant_dili.yml

### DIFF
--- a/config/ground-truth-yaml-files/all_features_version_10_no_visit_variant_dili.yml
+++ b/config/ground-truth-yaml-files/all_features_version_10_no_visit_variant_dili.yml
@@ -19,10 +19,10 @@ patient:
     search_term: rs1363907_a      
   AugmentinRx:
     categories:
+    - biolink:SmallMolecule
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    - biolink:SmallMolecule
     enum:
     - '0'
     - '1'
@@ -722,10 +722,10 @@ patient:
     search_term: elevated international normalised ratio, elevated prothrombin time
   Implicated_Drug1_Assessment:
     categories:
+    - biolink:SmallMolecule
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    - biolink:SmallMolecule
     enum: &id176
     - Possible 25-50%
     - Probable 50-75%
@@ -734,10 +734,10 @@ patient:
     type: string
   Implicated_Drug2_Assessment:
     categories:
+    - biolink:SmallMolecule
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    - biolink:SmallMolecule
     enum: &id177
     - Possible 25-50%
     - Probable 50-75%
@@ -746,10 +746,10 @@ patient:
     type: string
   Implicated_Drug3_Assessment:
     categories:
+    - biolink:SmallMolecule
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    - biolink:SmallMolecule
     enum: &id178
     - Possible 25-50%
     - Probable 50-75%
@@ -897,10 +897,10 @@ patient:
     search_term: cholestatic liver disease, hepatocellular liver disease
   PrednisoneOrCorticosteroids_Rx:
     categories:
+    - biolink:SmallMolecule
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    - biolink:SmallMolecule
     enum: &id239
     - '0'
     - '1'
@@ -1034,20 +1034,20 @@ patient:
     search_term: liver disease, liver dysfunction
   WHONAME_Implicated_Drug1:
     categories:
+    - biolink:SmallMolecule
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    - biolink:SmallMolecule
     enum: &id326
     - Amoxicillin W/Clavulanic Acid
     - Other
     type: string
   WHONAME_Implicated_Drug2:
     categories:
+    - biolink:SmallMolecule
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    - biolink:SmallMolecule
     enum: &id327
     - Amoxicillin
     - Telithromycin
@@ -1069,10 +1069,10 @@ patient:
     type: string
   WHONAME_Implicated_Drug3:
     categories:
+    - biolink:SmallMolecule
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    - biolink:SmallMolecule
     enum: &id328
     - Ivermectin
     - Levofloxacin


### PR DESCRIPTION
Changed order of Biolink categories for all feature variables mapped to biolink:SmallMolecule, which should now be the first mapping.