### PR TITLE
Remove space in feature category

### DIFF
--- a/config/ground-truth-yaml-files/all_features_version_10_no_visit_variant_dili.yml
+++ b/config/ground-truth-yaml-files/all_features_version_10_no_visit_variant_dili.yml
@@ -822,7 +822,7 @@ patient:
     search_term: death
   LiverTransplant:
     categories:
-    - biolink:Clinical Intervention
+    - biolink:ClinicalIntervention
     enum: &id202
     - '0'
     - '1'


### PR DESCRIPTION
Remove an errant space in one of the feature categories.

This caused a fairly nuanced error that was causing Strider to not be able to use ICEES DILI as a KP.
This space was propagating to the `meta_knowledge_graph` endpoint, which the KP registry calls to get all valid KPs and figure out the queries they can respond to. The kp registry then validates these responses and makes sure that these are TRAPI compliant, but that space was failing validation. Strider uses the kp registry to do its query planning, and therefore ICEES was being excluded from the plan because it was technically invalid.