### PR TITLE
fixed duplicate enum id issue when creating sqlite db

### DIFF
--- a/config/ground-truth-yaml-files/all_features_version_10_no_visit_variant_pcd.yml
+++ b/config/ground-truth-yaml-files/all_features_version_10_no_visit_variant_pcd.yml
@@ -33,7 +33,7 @@ patient:
     categories:
     - biolink:Disease
     - biolink:DiseaseOrPhenotypicFeature
-    enum: &id168
+    enum: &id169
     - '0'
     - '1'
     - '>1'


### PR DESCRIPTION
This PR fixed the duplicate enum id issue since id168 is already used for another column. 