### PR TITLE
fixed dumplicate enum id issue for covid config

### DIFF
--- a/config/ground-truth-yaml-files/all_features_version_10_no_visit_variant_covid.yml
+++ b/config/ground-truth-yaml-files/all_features_version_10_no_visit_variant_covid.yml
@@ -1091,7 +1091,7 @@ patient:
     - biolink:ChemicalEntity
     - biolink:ChemicalExposure
     - biolink:Drug
-    enum: &id105
+    enum: &id108
     - '0'
     - '1'
     - '>1'
@@ -1747,7 +1747,7 @@ patient:
     categories:
     - biolink:Disease
     - biolink:DiseaseOrPhenotypicFeature
-    enum: &id103
+    enum: &id165
     - '0'
     - '1'
     - '>1'


### PR DESCRIPTION
@karafecho This PR fixed duplicate enum id issues for covid feature config file. When you update the yaml file to remove index, please work on top of this updated file to avoid this duplicate enum id issues from cropping up again.